### PR TITLE
Gradle 2.2, exposing caches volume, /app as volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,23 @@ RUN rm -rf /etc/Dockerfile
 ADD Dockerfile /etc/Dockerfile
 
 # Gradle
+ENV GRADLE_VERSION 2.2
 WORKDIR /usr/bin
-RUN wget https://services.gradle.org/distributions/gradle-2.1-all.zip && \
-    unzip gradle-2.1-all.zip && \
-    ln -s gradle-2.1 gradle && \
-    rm gradle-2.1-all.zip
+RUN wget "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-all.zip" && \
+    unzip "gradle-${GRADLE_VERSION}-all.zip" && \
+    ln -s "gradle-${GRADLE_VERSION}" gradle && \
+    rm "gradle-${GRADLE_VERSION}-all.zip"
 
 # Set Appropriate Environmental Variables
 ENV GRADLE_HOME /usr/bin/gradle
 ENV PATH $PATH:$GRADLE_HOME/bin
 
+# Caches
+VOLUME ["/root/.gradle/caches"]
+
 # Default command is "/usr/bin/gradle -version" on /app dir
 # (ie. Mount project at /app "docker --rm -v /path/to/app:/app gradle <command>")
-RUN mkdir /app
+VOLUME ["/app"]
 WORKDIR /app
-ENTRYPOINT ["gradle"] 
+ENTRYPOINT ["gradle"]
 CMD ["-version"]


### PR DESCRIPTION
Hey, thanks for this image!

I updated it to gradle 2.2 and added volume for caches.

With `-v /tmp/gradle-caches:/root/.gradle/caches` there's no need to download everything on each build. Feel free to update readme with caching info.

I wonder why this is needed:

```
 # In case someone loses the Dockerfile
 RUN rm -rf /etc/Dockerfile
 ADD Dockerfile /etc/Dockerfile
```

