### PR TITLE
Simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,14 @@ MAINTAINER Nicholas Iaquinto <nickiaq@gmail.com>
 
 # Gradle
 ENV GRADLE_VERSION 2.7
-ENV GRADLE_HASH fe801ce2166e6c5b48b3e7ba81277c41
+ENV GRADLE_SHA cde43b90945b5304c43ee36e58aab4cc6fb3a3d5f9bd9449bb1709a68371cb06
 WORKDIR /usr/lib
-RUN wget https://downloads.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip \
- && echo "${GRADLE_HASH} gradle-${GRADLE_VERSION}-bin.zip" > gradle-${GRADLE_VERSION}-bin.zip.md5 \
- && md5sum -c gradle-${GRADLE_VERSION}-bin.zip.md5 \
- && unzip "gradle-${GRADLE_VERSION}-bin.zip" \
+
+RUN curl -fl https://downloads.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -o gradle-bin.zip \
+ && echo "$GRADLE_SHA gradle-bin.zip" | sha256sum -c - \
+ && unzip "gradle-bin.zip" \
  && ln -s "/usr/lib/gradle-${GRADLE_VERSION}/bin/gradle" /usr/bin/gradle \
- && rm "gradle-${GRADLE_VERSION}-bin.zip" \
+ && rm "gradle-bin.zip" \
  && mkdir -p /usr/src/app
 
 # Set Appropriate Environmental Variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@ MAINTAINER Nicholas Iaquinto <nickiaq@gmail.com>
 ENV GRADLE_VERSION 2.7
 ENV GRADLE_HASH fe801ce2166e6c5b48b3e7ba81277c41
 WORKDIR /usr/lib
-RUN wget https://downloads.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip
-RUN echo "${GRADLE_HASH} gradle-${GRADLE_VERSION}-bin.zip" > gradle-${GRADLE_VERSION}-bin.zip.md5
-RUN md5sum -c gradle-${GRADLE_VERSION}-bin.zip.md5
-RUN unzip "gradle-${GRADLE_VERSION}-bin.zip"
-RUN ln -s "/usr/lib/gradle-${GRADLE_VERSION}/bin/gradle" /usr/bin/gradle
-RUN rm "gradle-${GRADLE_VERSION}-bin.zip"
-RUN mkdir -p /usr/src/app
+RUN wget https://downloads.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip \
+ && echo "${GRADLE_HASH} gradle-${GRADLE_VERSION}-bin.zip" > gradle-${GRADLE_VERSION}-bin.zip.md5 \
+ && md5sum -c gradle-${GRADLE_VERSION}-bin.zip.md5 \
+ && unzip "gradle-${GRADLE_VERSION}-bin.zip" \
+ && ln -s "/usr/lib/gradle-${GRADLE_VERSION}/bin/gradle" /usr/bin/gradle \
+ && rm "gradle-${GRADLE_VERSION}-bin.zip" \
+ && mkdir -p /usr/src/app
 
 # Set Appropriate Environmental Variables
 ENV GRADLE_HOME /usr/src/gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ MAINTAINER Nicholas Iaquinto <nickiaq@gmail.com>
 # Gradle
 ENV GRADLE_VERSION 2.7
 ENV GRADLE_SHA cde43b90945b5304c43ee36e58aab4cc6fb3a3d5f9bd9449bb1709a68371cb06
-WORKDIR /usr/lib
 
-RUN curl -fl https://downloads.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -o gradle-bin.zip \
+RUN cd /usr/lib \
+ && curl -fl https://downloads.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -o gradle-bin.zip \
  && echo "$GRADLE_SHA gradle-bin.zip" | sha256sum -c - \
  && unzip "gradle-bin.zip" \
  && ln -s "/usr/lib/gradle-${GRADLE_VERSION}/bin/gradle" /usr/bin/gradle \
@@ -18,11 +18,10 @@ ENV GRADLE_HOME /usr/src/gradle
 ENV PATH $PATH:$GRADLE_HOME/bin
 
 # Caches
-VOLUME /root/.gradle/caches
+VOLUME ["/root/.gradle/caches", "/usr/bin/app"]
 
 # Default command is "/usr/bin/gradle -version" on /usr/bin/app dir
 # (ie. Mount project at /usr/bin/app "docker --rm -v /path/to/app:/usr/bin/app gradle <command>")
-VOLUME /usr/bin/app
-WORKDIR /usr/bin/app
-ENTRYPOINT gradle
-CMD -version
+WORKDIR ["/usr/bin/app"]
+ENTRYPOINT ["gradle"]
+CMD ["-version"]


### PR DESCRIPTION
I found this image very useful. Thank you!

This PR:
- Reduces the number of layers by having a single RUN command
- Replaces checksum from md5 to sh256, same of gradle-wrapper
- Keep a single WORKDIR command
- Keep a single VOLUME command

It is mostly based on [Dockerfile best practices](https://docs.docker.com/engine/articles/dockerfile_best-practices/) and some official images.