### PR TITLE
WORKDIR shouldn't have square brackets round it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ VOLUME ["/root/.gradle/caches", "/usr/bin/app"]
 
 # Default command is "/usr/bin/gradle -version" on /usr/bin/app dir
 # (ie. Mount project at /usr/bin/app "docker --rm -v /path/to/app:/usr/bin/app gradle <command>")
-WORKDIR ["/usr/bin/app"]
+WORKDIR /usr/bin/app
 ENTRYPOINT ["gradle"]
 CMD ["-version"]


### PR DESCRIPTION
It's just being used as part of the directory name.

```
$ docker run --rm --entrypoint pwd niaquinto/gradle -
pwd: ignoring non-option arguments
/[/usr/bin/app]
```